### PR TITLE
CMake: Disable BUILD_TESTING for toml-f when WITH_TEST=OFF

### DIFF
--- a/config/modules/Findtoml-f.cmake
+++ b/config/modules/Findtoml-f.cmake
@@ -25,6 +25,11 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/crest-utils.cmake")
 
+if(NOT WITH_TESTS)
+  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+  set(BUILD_TESTING OFF)
+endif()
+
 crest_find_package("${_lib}" "${${_pkg}_FIND_METHOD}" "${_url}" "${_branch}")
 
 if(TARGET "toml-f::toml-f")

--- a/config/modules/Findtoml-f.cmake
+++ b/config/modules/Findtoml-f.cmake
@@ -26,6 +26,7 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/crest-utils.cmake")
 
 if(NOT WITH_TESTS)
+  # toml-f uses BUILD_TESTING instead of WITH_TESTS.
   set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
   set(BUILD_TESTING OFF)
 endif()


### PR DESCRIPTION
Package `toml-f` use a more general option name, `BUILD_TESTING`, rather than `WITH_TESTS`. Therefore, `WITH_TESTS=OFF` flag won't be passed to `toml-f`, and `toml-f` will keep building unittests, which requires `test-drive` whose finding logic is disabled through `WITH_TESTS=OFF` set by crest. This is the reason why with flag `WITH_TESTS=OFF` CMake still downloads `test-drive` even if it exists in `subprojects/` directory, and this PR is a simple workflow to fix the issue.